### PR TITLE
Add test modules under `other-modules`.

### DIFF
--- a/friday.cabal
+++ b/friday.cabal
@@ -86,6 +86,8 @@ Test-Suite      test
     type:       exitcode-stdio-1.0
 
     main-is:            Test.hs
+    other-modules:      Test.Vision.Histogram
+                        Test.Vision.Image
     ghc-options:        -Wall -O2 -rtsopts
     hs-source-dirs:     test/
     default-language:   Haskell2010


### PR DESCRIPTION
This ensures that the modules containing the tests are included into the tarball generated by `cabal sdist`. Without these modules one cannot build and run the test suite inside a downloaded tarball.

This also affects the `friday` package on Hackage. Note the appearance of the test directory at https://hackage.haskell.org/package/friday-0.2.1.1/src/