### PR TITLE
Using safer (!?) for vector indexing

### DIFF
--- a/src/Vision/Image/Type.hs
+++ b/src/Vision/Image/Type.hs
@@ -54,7 +54,7 @@ instance Storable p => MaskedImage (Manifest p) where
     shape = manifestSize
     {-# INLINE shape #-}
 
-    Manifest _ vec `maskedLinearIndex` ix = Just $! vec V.! ix
+    Manifest _ vec `maskedLinearIndex` ix = vec V.!? ix
     {-# INLINE maskedLinearIndex #-}
 
     values = manifestVector


### PR DESCRIPTION
Replaced call to `Data.Vector.(!)` with the safer `Data.Vector.(!?)` that results in a `Maybe`.