### PR TITLE
Bump dependency upper bound on primitive

### DIFF
--- a/friday.cabal
+++ b/friday.cabal
@@ -82,7 +82,7 @@ library
                       , containers              >= 0.4          && < 0.7.0.0
                       , convertible             >= 1            && < 2
                       , deepseq                 >= 1.3          && < 2
-                      , primitive               >= 0.5.2.1      && < 0.7
+                      , primitive               >= 0.5.2.1      && < 0.8
                       , ratio-int               >= 0.1.2        && < 0.2
                       , vector                  >= 0.10.0.1     && < 1
                       , transformers            >= 0.3          && < 0.6


### PR DESCRIPTION
This unbreaks the build in nixpkgs.